### PR TITLE
[Reviewer: Rob] Support round-robin DNS lookup

### DIFF
--- a/call.cpp
+++ b/call.cpp
@@ -790,6 +790,10 @@ bool call::connect_socket_if_needed()
   } else { /* TCP, SCTP or TLS. */
     struct sockaddr_storage L_dest;
 
+    /* Resolve the remote host again.  This replicates the function (and code)
+     * of the open_connections function in sipp.cpp.  Repeating this here
+     * (just before opening a new connection) means that we'll round-robin our
+     * connections across all IP addresses to which the host resolves. */
     struct addrinfo   hints;
     struct addrinfo * local_addr;
 


### PR DESCRIPTION
Rob, please can you review this change to sipp to enable round-robin DNS?

Basically, we just do the getaddrinfo call every time we create a new connection.  Since we have dnsmasq installed locally, this is always a local lookup.  In fact, if you're using an IP address rather than a hostname (the normal way we run this), it's purely a local function call.

There's also a tweak to the congestion control stuff (which I added) at line 1550 - the congested check is superfluous here, and the `call_socket` variable isn't always set up correctly.
