### PR TITLE
[Reviewer: Andrew] Send transaction responses to the correct peer

### DIFF
--- a/include/call.hpp
+++ b/include/call.hpp
@@ -74,8 +74,8 @@ public:
 
     virtual ~call();
 
-    virtual bool process_incoming(char * msg, struct sockaddr_storage *src = NULL);
-    virtual bool  process_twinSippCom(char * msg);
+    virtual bool process_incoming(char* msg, struct sockaddr_storage* src = NULL, SIPpSocket* sock = NULL);
+    virtual bool process_twinSippCom(char * msg);
 
     virtual bool run();
     /* Terminate this call, depending on action results and timewait. */
@@ -195,6 +195,10 @@ protected:
     SIPpSocket *call_remote_socket;
     int            call_port;
 
+    // Map of transactions to the socket used for them, in case different
+    // transactions in this call came from different remote IP addresses.
+    std::map<std::string, SIPpSocket*> txn_sockets;
+
     void         * comp_state;
 
     int            deleted;
@@ -283,7 +287,7 @@ protected:
     void do_bookkeeping(message *curmsg);
 
     void  extract_cseq_method (char* responseCseq, char* msg);
-    void  extract_transaction (char* txn, char* msg);
+    void  extract_transaction (char* txn, const char* msg);
 
     int   send_raw(const char * msg, int index, int len);
     char * send_scene(int index, int *send_status, int *msgLen);

--- a/include/call.hpp
+++ b/include/call.hpp
@@ -75,7 +75,7 @@ public:
     virtual ~call();
 
     virtual bool process_incoming(char* msg, struct sockaddr_storage* src = NULL, SIPpSocket* sock = NULL);
-    virtual bool process_twinSippCom(char * msg);
+    virtual bool process_twinSippCom(char* msg);
 
     virtual bool run();
     /* Terminate this call, depending on action results and timewait. */

--- a/include/deadcall.hpp
+++ b/include/deadcall.hpp
@@ -3,11 +3,11 @@
 class deadcall : public virtual task, public virtual listener
 {
 public:
-    deadcall(const char *id, const char * reason);
+    deadcall(const char* id, const char* reason);
     ~deadcall();
 
-    virtual bool process_incoming(char * msg, struct sockaddr_storage *);
-    virtual bool  process_twinSippCom(char * msg);
+    virtual bool process_incoming(char* msg, struct sockaddr_storage* src, SIPpSocket* sock);
+    virtual bool process_twinSippCom(char* msg);
 
     virtual bool run();
 

--- a/include/listener.hpp
+++ b/include/listener.hpp
@@ -29,13 +29,15 @@
 
 #include "sipp.hpp"
 
+class SIPpSocket;
+
 class listener
 {
 public:
     listener(const char *id, bool listening);
     virtual ~listener();
     char *getId();
-    virtual bool process_incoming(char * msg, struct sockaddr_storage *src) = 0;
+    virtual bool process_incoming(char* msg, struct sockaddr_storage *src, SIPpSocket* sock) = 0;
     virtual bool process_twinSippCom(char * msg) = 0;
 
 protected:

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -806,7 +806,7 @@ int call::send_raw(const char * msg, int index, int len)
 {
     SIPpSocket *sock;
     int rc;
-    char            txn[MAX_HEADER_LEN];
+    char txn[MAX_HEADER_LEN];
 
     callDebug("Sending %s message for call %s (index %d, hash %lu):\n%s\n\n",
               TRANSPORT_TO_STRING(transport), id, index, hash(msg), msg);

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -547,6 +547,13 @@ call::~call()
         comp_free(&comp_state);
     }
 
+    for (std::map<std::string, SIPpSocket*>::iterator i = txn_sockets.begin(); i != txn_sockets.end(); i++) {
+        if ((i->second != NULL) && (i->second != call_remote_socket))
+        {
+            i->second->close();
+        }
+    }
+
     if (call_remote_socket && (call_remote_socket != main_remote_socket)) {
         call_remote_socket->close();
     }
@@ -799,6 +806,7 @@ int call::send_raw(const char * msg, int index, int len)
 {
     SIPpSocket *sock;
     int rc;
+    char            txn[MAX_HEADER_LEN];
 
     callDebug("Sending %s message for call %s (index %d, hash %lu):\n%s\n\n",
               TRANSPORT_TO_STRING(transport), id, index, hash(msg), msg);
@@ -816,6 +824,17 @@ int call::send_raw(const char * msg, int index, int len)
     }
 
     sock = call_socket;
+    extract_transaction(txn, msg);
+
+    /* The initial request for this transaction may have come from a different
+     * IP address and port than the initial request for this scenario. If so,
+     * send responses back to the same IP address and port - without this, we
+     * would send the response to whoever sent the initial request, and that
+     * peer won't know about this particular transaction.  */
+
+    if (txn_sockets[txn] != NULL) {
+        sock = txn_sockets[txn];
+    }
 
     if ((use_remote_sending_addr) && (sendMode == MODE_SERVER)) {
         if (!call_remote_socket) {
@@ -2520,7 +2539,7 @@ void call::extract_cseq_method (char* method, char* msg)
     }
 }
 
-void call::extract_transaction (char* txn, char* msg)
+void call::extract_transaction (char* txn, const char* msg)
 {
     char *via = get_header_content(msg, "via:");
     if (!via) {
@@ -2699,7 +2718,7 @@ void call::queue_up(char *msg)
     queued_msg = strdup(msg);
 }
 
-bool call::process_incoming(char * msg, struct sockaddr_storage *src)
+bool call::process_incoming(char * msg, struct sockaddr_storage *src, SIPpSocket* sock)
 {
     int             reply_code;
     static char     request[65];
@@ -2738,6 +2757,19 @@ bool call::process_incoming(char * msg, struct sockaddr_storage *src)
     if (!get_header(msg, "To:", false)[0] && !process_unexpected(msg)) {
         return false;
     }
+
+    extract_transaction (txn, msg);
+
+    /* If this request came from a different peer than the one who created this
+     * dialog, store off the socket, so that when we send responses on this
+     * transaction we can send them over this socket rather than the default
+     * call_socket.
+     */
+    if (sock && (sock != call_socket) && (txn_sockets[txn] == NULL)) {
+        sock->ss_count++;
+        txn_sockets[txn] = sock;
+    }
+
 
     if ((transport == T_UDP) && (retrans_enabled)) {
         /* Detects retransmissions from peer and retransmit the
@@ -2837,7 +2869,6 @@ bool call::process_incoming(char * msg, struct sockaddr_storage *src)
         request[0]=0;
         // extract the cseq method from the response
         extract_cseq_method (responsecseqmethod, msg);
-        extract_transaction (txn, msg);
     } else if((ptr = strchr(msg, ' '))) {
         if((ptr - msg) < 64) {
             memcpy(request, msg, ptr - msg);

--- a/src/deadcall.cpp
+++ b/src/deadcall.cpp
@@ -64,7 +64,7 @@ deadcall::~deadcall()
     free(reason);
 }
 
-bool deadcall::process_incoming(char * msg, struct sockaddr_storage * /*src*/)
+bool deadcall::process_incoming(char * msg, struct sockaddr_storage * /*src*/, SIPpSocket* /*sock*/)
 {
     char buffer[MAX_HEADER_LEN];
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1267,7 +1267,7 @@ void process_message(SIPpSocket *socket, char *msg, ssize_t msg_size, struct soc
     if ((socket == localTwinSippSocket) || (socket == twinSippSocket) || (is_a_local_socket(socket))) {
         listener_ptr -> process_twinSippCom(msg);
     } else {
-        listener_ptr -> process_incoming(msg, src);
+        listener_ptr -> process_incoming(msg, src, socket);
     }
 }
 


### PR DESCRIPTION
This fixes the bug you hit with PRACK responses going to the wrong place. The basic logic is:

* when we get a request, store off the socket we received it on, keyed off the transaction ID (in the txn_sockets map)
* when we send a response on a transaction, look up our transaction ID to find that socket again

I've tested live.