### PR TITLE
[No reviewer] Build sipp and sipp_static separately

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 @AM_GIT_VERSION@
 
-bin_PROGRAMS = sipp
+bin_PROGRAMS = sipp sipp_static
 
 TESTS = sipp_unittest
 
@@ -131,7 +131,13 @@ sipp_SOURCES = \
 
 sipp_CFLAGS = $(AM_CFLAGS) @GSL_CFLAGS@
 sipp_CXXFLAGS = $(AM_CXXFLAGS) @GSL_CXXFLAGS@
-sipp_LDADD = @LIBOBJS@ @GSL_LIBS@ -lcurses -ltinfo
+sipp_LDADD = @LIBOBJS@ @GSL_LIBS@
+
+sipp_static_SOURCES = $(sipp_SOURCES)
+sipp_static_CFLAGS = $(sipp_CFLAGS)
+sipp_static_CXXFLAGS = $(sipp_CXXFLAGS)
+sipp_static_LDFLAGS = -static $(sipp_LDFLAGS)
+sipp_static_LDADD = $(sipp_LDADD) -lcurses -ltinfo
 
 # call.cpp and sipp.cpp use version.h; see AM_GIT_VERSION.
 src/call.cpp: include/version.h

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ case "$host" in
     *-linux*)
         CFLAGS="$CFLAGS -D__LINUX"
         CPPFLAGS="$CPPFLAGS -D__LINUX"
-        LDFLAGS="$LDFLAGS -static"
+        LDFLAGS="$LDFLAGS"
         ;;
     *-darwin*)
         CFLAGS="$CFLAGS -D__DARWIN"
@@ -86,8 +86,14 @@ case "$host" in
 esac
 
 # ==================== checks for libraries =============================
-AC_SEARCH_LIBS([initscr], [curses, ncurses, tinfo])
-AC_SEARCH_LIBS([scroll_csr_backward], [tinfo])
+AC_CHECK_LIB(curses,initscr)
+if test x$ac_cv_lib_curses_initscr = xno; then
+    AC_CHECK_LIB(ncurses,initscr)
+    if test x$ac_cv_lib_ncurses_initscr = xno; then
+        AC_MSG_ERROR([ncurses library missing])
+    fi
+fi
+
 
 AC_CHECK_LIB(pthread, pthread_mutex_init, THREAD_LIBS="-lpthread",
     AC_MSG_ERROR(pthread library needed!))

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -70,11 +70,17 @@
 /* Define to 1 if you have the `crypto' library (-lcrypto). */
 #undef HAVE_LIBCRYPTO
 
+/* Define to 1 if you have the `curses' library (-lcurses). */
+#undef HAVE_LIBCURSES
+
 /* Define to 1 if you have the `gslcblas' library (-lgslcblas). */
 #undef HAVE_LIBGSLCBLAS
 
 /* Define to 1 if you have the `m' library (-lm). */
 #undef HAVE_LIBM
+
+/* Define to 1 if you have the `ncurses' library (-lncurses). */
+#undef HAVE_LIBNCURSES
 
 /* Define to 1 if you have the `ssl' library (-lssl). */
 #undef HAVE_LIBSSL


### PR DESCRIPTION
I've hit https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=757941 when trying to use static linking outside of containers, so this reverts static linking from being the default.